### PR TITLE
fix: make keycloak issuer configurable

### DIFF
--- a/kienlongbank-project/api-gateway/src/main/resources/application.yml
+++ b/kienlongbank-project/api-gateway/src/main/resources/application.yml
@@ -31,9 +31,10 @@ spring:
       resourceserver:
         jwt:
           # issuer-uri: http://localhost:8090/realms/Kienlongbank
-          issuer-uri: http://keycloak:8080/realms/Kienlongbank
+          # Use environment variable KEYCLOAK_HOST to allow running outside Docker
+          issuer-uri: http://${KEYCLOAK_HOST:localhost}:8080/realms/Kienlongbank
           # Alternative configuration using JWKS URI directly (more reliable)
-          # jwk-set-uri: http://klb-keycloak:8080/realms/Kienlongbank/protocol/openid-connect/certs
+          jwk-set-uri: http://${KEYCLOAK_HOST:localhost}:8080/realms/Kienlongbank/protocol/openid-connect/certs
 
 server:
   port: 8080
@@ -55,3 +56,4 @@ logging:
     # Giữ lại các log security để gỡ lỗi
     org.springframework.security: DEBUG
     org.springframework.security.oauth2.server.resource: DEBUG
+

--- a/kienlongbank-project/customer-service/src/main/resources/application.yml
+++ b/kienlongbank-project/customer-service/src/main/resources/application.yml
@@ -36,8 +36,9 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://keycloak:8080/realms/Kienlongbank
-          jwk-set-uri: http://keycloak:8080/realms/Kienlongbank/protocol/openid-connect/certs
+          # Use KEYCLOAK_HOST env to switch between Docker and local development
+          issuer-uri: http://${KEYCLOAK_HOST:localhost}:8080/realms/Kienlongbank
+          jwk-set-uri: http://${KEYCLOAK_HOST:localhost}:8080/realms/Kienlongbank/protocol/openid-connect/certs
     method:
       pre-post-enabled: true
 
@@ -123,3 +124,4 @@ dubbo:
   protocol:
     name: dubbo
     port: 20881
+

--- a/kienlongbank-project/main-app/src/main/resources/application.properties
+++ b/kienlongbank-project/main-app/src/main/resources/application.properties
@@ -29,9 +29,9 @@ spring.rabbitmq.port=5672
 spring.rabbitmq.username=guest
 spring.rabbitmq.password=guest
 
-# JWT issuer URI - sử dụng localhost khi chạy ngoài Docker
-# spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8090/realms/Kienlongbank
-spring.security.oauth2.resourceserver.jwt.issuer-uri=klb-keycloak:8080/realms/Kienlongbank
+# JWT issuer URI - use KEYCLOAK_HOST to support Docker and local runs
+spring.security.oauth2.resourceserver.jwt.issuer-uri=http://${KEYCLOAK_HOST:localhost}:8080/realms/Kienlongbank
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://${KEYCLOAK_HOST:localhost}:8080/realms/Kienlongbank/protocol/openid-connect/certs
 
 # Disable Spring Cloud compatibility check
 spring.cloud.compatibility-verifier.enabled=false

--- a/klb-frontend/src/components/CustomerInfoPage.tsx
+++ b/klb-frontend/src/components/CustomerInfoPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useCustomAuth from '../hooks/useCustomAuth';
 import api from '../config/api';
+import customKeycloakService from '../services/customKeycloakService';
 
 interface CustomerInfo {
     id?: number;
@@ -56,11 +57,12 @@ const CustomerInfoPage: React.FC = () => {
             setError('');
 
             // Gọi trực tiếp Customer Service (port 8082)
+            const token = customKeycloakService.getToken();
             const response = await fetch('http://localhost:8082/api/customers/my-info', {
                 method: 'GET',
                 headers: {
                     'Content-Type': 'application/json',
-                    // TODO: Add Authorization header with JWT token
+                    ...(token ? { 'Authorization': `Bearer ${token}` } : {})
                 }
             });
 
@@ -116,11 +118,12 @@ const CustomerInfoPage: React.FC = () => {
             setSuccess('');
 
             // Gọi trực tiếp Customer Service để cập nhật thông tin
+            const token = customKeycloakService.getToken();
             const response = await fetch('http://localhost:8082/api/customers/my-info', {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json',
-                    // TODO: Add Authorization header with JWT token
+                    ...(token ? { 'Authorization': `Bearer ${token}` } : {})
                 },
                 body: JSON.stringify(editForm)
             });


### PR DESCRIPTION
## Summary
- allow configuring Keycloak host through KEYCLOAK_HOST for API gateway
- use KEYCLOAK_HOST in customer and main services for token validation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a6952b0b48832ea39e33c5e4c589d2